### PR TITLE
add FaultyPort impl and soft recovery to Initializing on FaultCleared

### DIFF
--- a/crates/rptp/src/bmca.rs
+++ b/crates/rptp/src/bmca.rs
@@ -215,6 +215,11 @@ impl<'a, S: ForeignClockRecords> ListeningBmca<'a, S> {
         let current_grandmaster_id = self.bmca.using_grandmaster(|gm| *gm.identity());
         self.into_grandmaster_tracking(current_grandmaster_id)
     }
+
+    /// Decompose ListeningBmca into its parts.
+    pub(crate) fn into_parts(self) -> (BestMasterClockAlgorithm<'a>, BestForeignRecord<S>) {
+        (self.bmca, self.best_foreign)
+    }
 }
 
 impl<'a, S: ForeignClockRecords> Bmca for ListeningBmca<'a, S> {
@@ -318,6 +323,11 @@ impl<'a, S: ForeignClockRecords> GrandMasterTrackingBmca<'a, S> {
     ) -> ParentTrackingBmca<'a, S> {
         ParentTrackingBmca::new(self.bmca, self.best_foreign, parent_port_identity)
     }
+
+    /// Decompose GrandMasterTrackingBmca into its parts.
+    pub(crate) fn into_parts(self) -> (BestMasterClockAlgorithm<'a>, BestForeignRecord<S>) {
+        (self.bmca, self.best_foreign)
+    }
 }
 
 impl<'a, S: ForeignClockRecords> Bmca for GrandMasterTrackingBmca<'a, S> {
@@ -409,6 +419,11 @@ impl<'a, S: ForeignClockRecords> ParentTrackingBmca<'a, S> {
     pub(crate) fn into_current_grandmaster_tracking(self) -> GrandMasterTrackingBmca<'a, S> {
         let current_grandmaster_id = self.bmca.using_grandmaster(|gm| *gm.identity());
         self.into_grandmaster_tracking(current_grandmaster_id)
+    }
+
+    /// Decompose ParentTrackingBmca into its parts.
+    pub(crate) fn into_parts(self) -> (BestMasterClockAlgorithm<'a>, BestForeignRecord<S>) {
+        (self.bmca, self.best_foreign)
     }
 }
 

--- a/crates/rptp/src/listening.rs
+++ b/crates/rptp/src/listening.rs
@@ -126,6 +126,12 @@ impl<'a, P: Port, S: ForeignClockRecords> ListeningPort<'a, P, S> {
             None => None,
         }
     }
+
+    /// Transition to `FAULTY` upon fault detection.
+    pub(crate) fn fault_detected(self) -> PortState<'a, P, S> {
+        let (bmca, best_foreign) = self.bmca.into_parts();
+        self.profile.faulty(self.port, bmca, best_foreign)
+    }
 }
 
 #[cfg(test)]

--- a/crates/rptp/src/master.rs
+++ b/crates/rptp/src/master.rs
@@ -184,6 +184,11 @@ impl<'a, P: Port, S: ForeignClockRecords> MasterPort<'a, P, S> {
 
         self.profile.uncalibrated(self.port, bmca)
     }
+
+    pub(crate) fn fault_detected(self) -> PortState<'a, P, S> {
+        let (bmca, best_foreign) = self.bmca.into_parts();
+        self.profile.faulty(self.port, bmca, best_foreign)
+    }
 }
 
 /// Announce message sequencing and scheduling.

--- a/crates/rptp/src/message.rs
+++ b/crates/rptp/src/message.rs
@@ -160,6 +160,7 @@ pub enum SystemMessage {
     SyncTimeout,
     Timestamp(TimestampMessage),
     Initialized,
+    FaultCleared,
     AnnounceReceiptTimeout,
     QualificationTimeout,
 }

--- a/crates/rptp/src/premaster.rs
+++ b/crates/rptp/src/premaster.rs
@@ -113,6 +113,12 @@ impl<'a, P: Port, S: ForeignClockRecords> PreMasterPort<'a, P, S> {
 
         self.profile.uncalibrated(self.port, bmca)
     }
+
+    /// Transition to `FAULTY` upon fault detection.
+    pub(crate) fn fault_detected(self) -> PortState<'a, P, S> {
+        let (bmca, best_foreign) = self.bmca.into_parts();
+        self.profile.faulty(self.port, bmca, best_foreign)
+    }
 }
 
 #[cfg(test)]

--- a/crates/rptp/src/profile.rs
+++ b/crates/rptp/src/profile.rs
@@ -16,6 +16,7 @@ use crate::bmca::{
     ListeningBmca, ParentTrackingBmca, QualificationTimeoutPolicy,
 };
 use crate::e2e::{DelayCycle, EndToEndDelayMechanism};
+use crate::faulty::FaultyPort;
 use crate::initializing::InitializingPort;
 use crate::listening::ListeningPort;
 use crate::master::{AnnounceCycle, MasterPort, SyncCycle};
@@ -225,5 +226,17 @@ impl PortProfile {
             EndToEndDelayMechanism::new(delay_cycle),
             self,
         ))
+    }
+
+    /// Construct the `FAULTY` state.
+    ///
+    /// This variant is used when the port has detected a fault condition and is not operational.
+    pub(crate) fn faulty<P: Port, S: ForeignClockRecords>(
+        self,
+        port: P,
+        bmca: BestMasterClockAlgorithm,
+        best_foreign: BestForeignRecord<S>,
+    ) -> PortState<P, S> {
+        PortState::Faulty(FaultyPort::new(port, bmca, best_foreign, self))
     }
 }

--- a/crates/rptp/src/slave.rs
+++ b/crates/rptp/src/slave.rs
@@ -274,6 +274,12 @@ impl<'a, P: Port, S: ForeignClockRecords> SlavePort<'a, P, S> {
             self.profile,
         ))
     }
+
+    /// Transition to `FAULTY` upon fault detection.
+    pub(crate) fn fault_detected(self) -> PortState<'a, P, S> {
+        let (bmca, best_foreign) = self.bmca.into_parts();
+        self.profile.faulty(self.port, bmca, best_foreign)
+    }
 }
 
 #[cfg(test)]

--- a/crates/rptp/src/uncalibrated.rs
+++ b/crates/rptp/src/uncalibrated.rs
@@ -277,6 +277,12 @@ impl<'a, P: Port, S: ForeignClockRecords> UncalibratedPort<'a, P, S> {
 
         self.profile.uncalibrated(self.port, bmca)
     }
+
+    /// Transition to `FAULTY` upon fault detection.
+    pub(crate) fn fault_detected(self) -> PortState<'a, P, S> {
+        let (bmca, best_foreign) = self.bmca.into_parts();
+        self.profile.faulty(self.port, bmca, best_foreign)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #1 

## What Changed
Replaced the FaultyPort stub implemetation with real collaborators and behaviours, that are needed for a port to re-initialize again. Add transition methods from apprioriate port states into FaultyPort and a fault_cleared() method back to InitializingPort. PortProfile got a fault() factory methods, BMCA now can decompose themselves into its parts, that are to be re-assembled again on the fault-clear/reinitialization path.

## Why
See issue #1 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a functional `FAULTY` state and a recovery path back to initialization.
> 
> - New `FaultyPort` that holds `Port`, `BMCA`, and `BestForeignRecord`, with `fault_cleared()` returning `INITIALIZING`
> - Add `PortProfile::faulty` to construct `PortState::Faulty`
> - Extend transitions: `fault_detected()` from `LISTENING`, `SLAVE`, `MASTER`, `PRE_MASTER`, `UNCALIBRATED`; forbid in `INITIALIZING`
> - Add `SystemMessage::FaultCleared` and `StateDecision::FaultCleared`; wire into `dispatch_system`/`apply`
> - Expose `into_parts()` on `ListeningBmca`, `GrandMasterTrackingBmca`, `ParentTrackingBmca` for handoff into `FAULTY`
> - Tests updated/added for new transitions and recovery
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0e86a492dc6b72dd12e8253e1f6c2f9bdce58a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->