### PR TITLE
remove log_min_delay_request_interval() getter on PortProfile

### DIFF
--- a/crates/rptp/src/master.rs
+++ b/crates/rptp/src/master.rs
@@ -46,6 +46,7 @@ pub struct MasterPort<'a, P: Port, S: ForeignClockRecords> {
     bmca: GrandMasterTrackingBmca<'a, S>,
     announce_cycle: AnnounceCycle<P::Timeout>,
     sync_cycle: SyncCycle<P::Timeout>,
+    log_min_delay_request_interval: LogInterval,
     profile: PortProfile,
 }
 
@@ -56,6 +57,7 @@ impl<'a, P: Port, S: ForeignClockRecords> MasterPort<'a, P, S> {
         bmca: GrandMasterTrackingBmca<'a, S>,
         announce_cycle: AnnounceCycle<P::Timeout>,
         sync_cycle: SyncCycle<P::Timeout>,
+        log_min_delay_request_interval: LogInterval,
         profile: PortProfile,
     ) -> Self {
         port.log(PortEvent::Static("Become MasterPort"));
@@ -65,6 +67,7 @@ impl<'a, P: Port, S: ForeignClockRecords> MasterPort<'a, P, S> {
             bmca,
             announce_cycle,
             sync_cycle,
+            log_min_delay_request_interval,
             profile,
         }
     }
@@ -119,9 +122,7 @@ impl<'a, P: Port, S: ForeignClockRecords> MasterPort<'a, P, S> {
         self.port.log(PortEvent::MessageReceived("DelayReq"));
 
         let response = req.response(
-            self.profile
-                .log_min_delay_request_interval()
-                .log_message_interval(),
+            self.log_min_delay_request_interval.log_message_interval(),
             ingress_timestamp,
             requesting_port_identity,
         );
@@ -357,6 +358,7 @@ mod tests {
             );
             let grandmaster_id = *self.local_clock.identity();
 
+            let default_profile = PortProfile::default();
             MasterPort::new(
                 domain_port,
                 GrandMasterTrackingBmca::new(
@@ -373,7 +375,8 @@ mod tests {
                 ),
                 announce_cycle,
                 sync_cycle,
-                PortProfile::default(),
+                LogInterval::new(0),
+                default_profile,
             )
         }
     }

--- a/crates/rptp/src/profile.rs
+++ b/crates/rptp/src/profile.rs
@@ -86,14 +86,6 @@ impl Default for PortProfile {
 }
 
 impl PortProfile {
-    /// Return the configured `logMinDelayReqInterval`.
-    ///
-    /// This is commonly embedded into outgoing Announce messages so other nodes can understand
-    /// the slave’s expected delay-request pacing.
-    pub(crate) fn log_min_delay_request_interval(&self) -> LogInterval {
-        self.log_min_delay_request_interval
-    }
-
     /// Construct the `INITIALIZING` state.
     ///
     /// This variant is used while infrastructure and BMCA bookkeeping are being brought up.
@@ -131,7 +123,7 @@ impl PortProfile {
 
     /// Construct the `MASTER` state and start the periodic Announce/Sync schedules.
     ///
-    /// Both cycles are started with an initial “send immediately” timeout (`0s`) so a newly
+    /// Both cycles are started with an initial "send immediately" timeout (`0s`) so a newly
     /// elected master begins announcing and synchronizing without waiting for a full interval.
     pub(crate) fn master<P: Port, S: ForeignClockRecords>(
         self,
@@ -151,6 +143,7 @@ impl PortProfile {
             bmca,
             announce_cycle,
             sync_cycle,
+            self.log_min_delay_request_interval,
             self,
         ))
     }


### PR DESCRIPTION
Fixes #2 

## What Changed

Removed log_min_delay_request_interval() getter on PortProfile. 

## Why

See #2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies how the `logMinDelayReqInterval` is accessed by removing the `PortProfile` getter and threading the value directly into `MasterPort`.
> 
> - `MasterPort` now stores `log_min_delay_request_interval` and uses it in `process_delay_request`
> - `PortProfile::master` passes the interval into `MasterPort::new`; obsolete getter removed from `PortProfile`
> - Tests updated to construct `MasterPort` with the explicit interval
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7cfbf8c8dbcc2c87d1b68f7ca8f11537c618e18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->